### PR TITLE
DatatypeContexts is required by Graphics.Rendering.OpenGL.GL.Evaluators

### DIFF
--- a/Graphics/Rendering/OpenGL/GL/Evaluators.hs
+++ b/Graphics/Rendering/OpenGL/GL/Evaluators.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DatatypeContexts #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.OpenGL.GL.Evaluators


### PR DESCRIPTION
Adds using a LANGUAGE pragma
