### PR TITLE
Hide cabal-dev simlink.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/cabal-dev/
+/cabal-dev
 /dist/
 *.swp


### PR DESCRIPTION
The cabal-dev simlink wasn't blocked by the gitignore, only a normal directory.
