### PR TITLE
Fixed ObjectName instance for VertexArrayObject.

### DIFF
--- a/Graphics/Rendering/OpenGL/GL/VertexArrayObjects.hs
+++ b/Graphics/Rendering/OpenGL/GL/VertexArrayObjects.hs
@@ -36,7 +36,7 @@ instance ObjectName VertexArrayObject where
       fmap (map VertexArrayObject) $ peekArray n buf
    deleteObjectNames bufferObjects =
       withArrayLen (map vertexArrayID bufferObjects) $
-         glDeleteBuffers . fromIntegral
+         glDeleteVertexArrays . fromIntegral
    isObjectName =  fmap unmarshalGLboolean . glIsVertexArray . vertexArrayID
 
 bindVertexArrayObject :: StateVar (Maybe VertexArrayObject)


### PR DESCRIPTION
The previous implementation failed to actually delete VAOs with
deleteObjectNames, thereby creating a memory leak.
