### PR TITLE
Switch generateMipmap to the new OpenGL 3.0 functionality

### DIFF
--- a/Graphics/Rendering/OpenGL/GL/Texturing/Objects.hs
+++ b/Graphics/Rendering/OpenGL/GL/Texturing/Objects.hs
@@ -16,7 +16,8 @@
 module Graphics.Rendering.OpenGL.GL.Texturing.Objects (
    TextureObject(TextureObject), textureBinding,
    textureResident, areTexturesResident,
-   TexturePriority, texturePriority, prioritizeTextures
+   TexturePriority, texturePriority, prioritizeTextures,
+   generateMipmap
 ) where
 
 import Data.List
@@ -74,3 +75,7 @@ prioritizeTextures tps =
    withArrayLen (map (textureID . fst) tps) $ \len texObjsBuf ->
       withArray (map snd tps) $
          glPrioritizeTextures (fromIntegral len) texObjsBuf
+
+
+generateMipmap :: ParameterizedTextureTarget t => t -> IO ()
+generateMipmap t = glGenerateMipmap $ marshalParameterizedTextureTarget t

--- a/Graphics/Rendering/OpenGL/GL/Texturing/Parameters.hs
+++ b/Graphics/Rendering/OpenGL/GL/Texturing/Parameters.hs
@@ -19,7 +19,7 @@ module Graphics.Rendering.OpenGL.GL.Texturing.Parameters (
    Repetition(..), Clamping(..), textureWrapMode,
    textureBorderColor, LOD, textureObjectLODBias, maxTextureLODBias,
    textureLODRange, textureMaxAnisotropy, maxTextureMaxAnisotropy,
-   textureLevelRange, generateMipmap, depthTextureMode, textureCompareMode,
+   textureLevelRange, textureGenerateMipmap, depthTextureMode, textureCompareMode,
    textureCompareFailValue, TextureCompareOperator(..), textureCompareOperator
 ) where
 
@@ -140,8 +140,10 @@ textureLevelRange =
 
 --------------------------------------------------------------------------------
 
-generateMipmap :: ParameterizedTextureTarget t => t -> StateVar Capability
-generateMipmap = texParami unmarshal marshal GenerateMipmap
+-- Refers to the generate mipmap parameter introduced in OpenGL 1.4 and
+-- deprecated in OpenGL 3.0
+textureGenerateMipmap :: ParameterizedTextureTarget t => t -> StateVar Capability
+textureGenerateMipmap = texParami unmarshal marshal GenerateMipmap
    where unmarshal = unmarshalCapability . fromIntegral
          marshal = fromIntegral . marshalCapability
 


### PR DESCRIPTION
HOpenGL's generateMipmap function was bound to the texture environment state variable introduced
in OpenGL 1.4 and subsequently deprecated in OpenGL 3.0. It is removed altogether in OpenGL 3.1 and
may cause confusion with glGenerateMipmap. This new function was introduced to allow automatic
mipmap generation.

See http://www.opengl.org/wiki/Common_Mistakes#Automatic_mipmap_generation
