### PR TITLE
Add tessellation functionality

### DIFF
--- a/OpenGL.cabal
+++ b/OpenGL.cabal
@@ -64,6 +64,7 @@ library
     Graphics.Rendering.OpenGL.GL.PixellikeObject
     Graphics.Rendering.OpenGL.GL.Points
     Graphics.Rendering.OpenGL.GL.Polygons
+    Graphics.Rendering.OpenGL.GL.PrimitiveMode
     Graphics.Rendering.OpenGL.GL.QueryObjects
     Graphics.Rendering.OpenGL.GL.RasterPos
     Graphics.Rendering.OpenGL.GL.ReadCopyPixels
@@ -126,7 +127,7 @@ library
     Graphics.Rendering.OpenGL.GL.PixelRectangles.Sink
     Graphics.Rendering.OpenGL.GL.PointParameter
     Graphics.Rendering.OpenGL.GL.PolygonMode
-    Graphics.Rendering.OpenGL.GL.PrimitiveMode
+    Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal
     Graphics.Rendering.OpenGL.GL.QueryObject
     Graphics.Rendering.OpenGL.GL.QueryUtils
     Graphics.Rendering.OpenGL.GL.QueryUtils.PName

--- a/src/Graphics/Rendering/OpenGL/GL.hs
+++ b/src/Graphics/Rendering/OpenGL/GL.hs
@@ -80,7 +80,7 @@ import Graphics.Rendering.OpenGL.GL.ObjectName
 import Graphics.Rendering.OpenGL.GL.SyncObjects
 import Graphics.Rendering.OpenGL.GL.QueryObjects
 
-import Graphics.Rendering.OpenGL.GL.PrimitiveMode,
+import Graphics.Rendering.OpenGL.GL.PrimitiveMode
 import Graphics.Rendering.OpenGL.GL.BeginEnd
 import Graphics.Rendering.OpenGL.GL.Rectangles
 import Graphics.Rendering.OpenGL.GL.ConditionalRendering

--- a/src/Graphics/Rendering/OpenGL/GL.hs
+++ b/src/Graphics/Rendering/OpenGL/GL.hs
@@ -24,6 +24,7 @@ module Graphics.Rendering.OpenGL.GL (
    module Graphics.Rendering.OpenGL.GL.QueryObjects,
 
    -- * Vertex Specification and Drawing Commands
+   module Graphics.Rendering.OpenGL.GL.PrimitiveMode,
    module Graphics.Rendering.OpenGL.GL.BeginEnd,
    module Graphics.Rendering.OpenGL.GL.Rectangles,
    module Graphics.Rendering.OpenGL.GL.ConditionalRendering,
@@ -79,6 +80,7 @@ import Graphics.Rendering.OpenGL.GL.ObjectName
 import Graphics.Rendering.OpenGL.GL.SyncObjects
 import Graphics.Rendering.OpenGL.GL.QueryObjects
 
+import Graphics.Rendering.OpenGL.GL.PrimitiveMode,
 import Graphics.Rendering.OpenGL.GL.BeginEnd
 import Graphics.Rendering.OpenGL.GL.Rectangles
 import Graphics.Rendering.OpenGL.GL.ConditionalRendering

--- a/src/Graphics/Rendering/OpenGL/GL/BeginEnd.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/BeginEnd.hs
@@ -3,7 +3,7 @@
 -- Module      :  Graphics.Rendering.OpenGL.GL.BeginEnd
 -- Copyright   :  (c) Sven Panne 2002-2013
 -- License     :  BSD3
--- 
+--
 -- Maintainer  :  Sven Panne <svenpanne@gmail.com>
 -- Stability   :  stable
 -- Portability :  portable
@@ -15,7 +15,6 @@
 
 module Graphics.Rendering.OpenGL.GL.BeginEnd (
    -- * Begin and End Objects
-   PrimitiveMode(..),
    renderPrimitive, unsafeRenderPrimitive, primitiveRestart,
 
    -- * Polygon Edges
@@ -27,6 +26,7 @@ import Graphics.Rendering.OpenGL.GL.StateVar
 import Graphics.Rendering.OpenGL.GL.EdgeFlag
 import Graphics.Rendering.OpenGL.GL.Exception
 import Graphics.Rendering.OpenGL.GL.PrimitiveMode
+import Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal
 import Graphics.Rendering.OpenGL.GL.QueryUtils
 import Graphics.Rendering.OpenGL.Raw
 

--- a/src/Graphics/Rendering/OpenGL/GL/PrimitiveMode.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/PrimitiveMode.hs
@@ -97,4 +97,5 @@ unmarshalPrimitiveMode x
    | x == gl_QUADS = Quads
    | x == gl_QUAD_STRIP = QuadStrip
    | x == gl_POLYGON = Polygon
+   | x == gl_PATCHES = Patches
    | otherwise = error ("unmarshalPrimitiveMode: illegal value " ++ show x)

--- a/src/Graphics/Rendering/OpenGL/GL/PrimitiveMode.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/PrimitiveMode.hs
@@ -66,6 +66,9 @@ data PrimitiveMode =
    | Polygon
      -- ^ Draws a single, convex polygon. Vertices 1 through /N/ define this
      -- polygon.
+   | Patches
+     -- ^ Only used in conjunction with tessellation. The number of vertices per
+     -- patch is configurable.
    deriving ( Eq, Ord, Show )
 
 marshalPrimitiveMode :: PrimitiveMode -> GLenum
@@ -80,6 +83,7 @@ marshalPrimitiveMode x = case x of
    Quads -> gl_QUADS
    QuadStrip -> gl_QUAD_STRIP
    Polygon -> gl_POLYGON
+   Patches -> gl_PATCHES
 
 unmarshalPrimitiveMode :: GLenum -> PrimitiveMode
 unmarshalPrimitiveMode x

--- a/src/Graphics/Rendering/OpenGL/GL/PrimitiveMode.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/PrimitiveMode.hs
@@ -1,22 +1,27 @@
-{-# OPTIONS_HADDOCK hide #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  Graphics.Rendering.OpenGL.GL.PrimitiveMode
--- Copyright   :  (c) Sven Panne 2002-2013
+-- Copyright   :  (c) Sven Panne 2002-2013, Tobias Markus 2015
 -- License     :  BSD3
--- 
+--
 -- Maintainer  :  Sven Panne <svenpanne@gmail.com>
 -- Stability   :  stable
 -- Portability :  portable
 --
--- This is a purely internal module for (un-)marshaling PrimitiveMode.
+-- This module corresponds to section 10.1 (Primitive Types) of the OpenGL 4.4
+-- specs.
 --
 --------------------------------------------------------------------------------
 
 module Graphics.Rendering.OpenGL.GL.PrimitiveMode (
-   PrimitiveMode(..), marshalPrimitiveMode, unmarshalPrimitiveMode
+   -- * Primitive Modes
+   PrimitiveMode(..),
+   -- * Patches (Tessellation)
+   patchVertices, maxPatchVertices
 ) where
 
+import Graphics.Rendering.OpenGL.GL.StateVar
+import Graphics.Rendering.OpenGL.GL.QueryUtils.PName
 import Graphics.Rendering.OpenGL.Raw
 
 --------------------------------------------------------------------------------
@@ -68,34 +73,19 @@ data PrimitiveMode =
      -- polygon.
    | Patches
      -- ^ Only used in conjunction with tessellation. The number of vertices per
-     -- patch is configurable.
+     -- patch can be set with 'patchVertices'.
    deriving ( Eq, Ord, Show )
 
-marshalPrimitiveMode :: PrimitiveMode -> GLenum
-marshalPrimitiveMode x = case x of
-   Points -> gl_POINTS
-   Lines -> gl_LINES
-   LineLoop -> gl_LINE_LOOP
-   LineStrip -> gl_LINE_STRIP
-   Triangles -> gl_TRIANGLES
-   TriangleStrip -> gl_TRIANGLE_STRIP
-   TriangleFan -> gl_TRIANGLE_FAN
-   Quads -> gl_QUADS
-   QuadStrip -> gl_QUAD_STRIP
-   Polygon -> gl_POLYGON
-   Patches -> gl_PATCHES
+-- | 'patchVertices' is the number of vertices per patch primitive.
+--
+-- An 'Graphics.Rendering.OpenGL.GLU.Errors.InvalidValue' is generated if
+-- 'patchVertices' is set to a value less than or equal to zero or greater
+-- than the implementation-dependent maximum value 'maxPatchVertices'.
 
-unmarshalPrimitiveMode :: GLenum -> PrimitiveMode
-unmarshalPrimitiveMode x
-   | x == gl_POINTS = Points
-   | x == gl_LINES = Lines
-   | x == gl_LINE_LOOP = LineLoop
-   | x == gl_LINE_STRIP = LineStrip
-   | x == gl_TRIANGLES = Triangles
-   | x == gl_TRIANGLE_STRIP = TriangleStrip
-   | x == gl_TRIANGLE_FAN = TriangleFan
-   | x == gl_QUADS = Quads
-   | x == gl_QUAD_STRIP = QuadStrip
-   | x == gl_POLYGON = Polygon
-   | x == gl_PATCHES = Patches
-   | otherwise = error ("unmarshalPrimitiveMode: illegal value " ++ show x)
+patchVertices :: SettableStateVar GLint
+patchVertices = makeSettableStateVar $ glPatchParameteri gl_PATCH_VERTICES
+
+-- | Contains the maximumum number of vertices in a single patch.
+
+maxPatchVertices :: GettableStateVar GLint
+maxPatchVertices = makeGettableStateVar $ getInteger1 id GetMaxPatchVertices

--- a/src/Graphics/Rendering/OpenGL/GL/PrimitiveModeInternal.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/PrimitiveModeInternal.hs
@@ -1,0 +1,52 @@
+{-# OPTIONS_HADDOCK hide #-}
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal
+-- Copyright   :  (c) Sven Panne 2002-2013
+-- License     :  BSD3
+--
+-- Maintainer  :  Sven Panne <svenpanne@gmail.com>
+-- Stability   :  stable
+-- Portability :  portable
+--
+-- This is a purely internal module for (un-)marshaling PrimitiveMode.
+--
+--------------------------------------------------------------------------------
+
+module Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal (
+   marshalPrimitiveMode, unmarshalPrimitiveMode
+) where
+
+import Graphics.Rendering.OpenGL.Raw
+import Graphics.Rendering.OpenGL.GL.PrimitiveMode
+
+--------------------------------------------------------------------------------
+
+marshalPrimitiveMode :: PrimitiveMode -> GLenum
+marshalPrimitiveMode x = case x of
+   Points -> gl_POINTS
+   Lines -> gl_LINES
+   LineLoop -> gl_LINE_LOOP
+   LineStrip -> gl_LINE_STRIP
+   Triangles -> gl_TRIANGLES
+   TriangleStrip -> gl_TRIANGLE_STRIP
+   TriangleFan -> gl_TRIANGLE_FAN
+   Quads -> gl_QUADS
+   QuadStrip -> gl_QUAD_STRIP
+   Polygon -> gl_POLYGON
+   Patches -> gl_PATCHES
+
+unmarshalPrimitiveMode :: GLenum -> PrimitiveMode
+unmarshalPrimitiveMode x
+   | x == gl_POINTS = Points
+   | x == gl_LINES = Lines
+   | x == gl_LINE_LOOP = LineLoop
+   | x == gl_LINE_STRIP = LineStrip
+   | x == gl_TRIANGLES = Triangles
+   | x == gl_TRIANGLE_STRIP = TriangleStrip
+   | x == gl_TRIANGLE_FAN = TriangleFan
+   | x == gl_QUADS = Quads
+   | x == gl_QUAD_STRIP = QuadStrip
+   | x == gl_POLYGON = Polygon
+   | x == gl_PATCHES = Patches
+   | otherwise = error ("unmarshalPrimitiveMode: illegal value " ++ show x)

--- a/src/Graphics/Rendering/OpenGL/GL/QueryUtils/PName.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/QueryUtils/PName.hs
@@ -366,6 +366,9 @@ data PName1I
     | GetMaxFragmentUniformComponents   -- ^ sizei
     | GetMaxVertexAttribs               -- ^ sizei
     | GetMaxVaryingFloats               -- ^ sizei
+    -- tessellation
+    | GetMaxPatchVertices               -- ^ int
+    | GetMaxTessellationLevel           -- ^ int
     -- coordtrans
     | GetMatrixMode                 -- ^ enum
     | GetModelviewStackDepth        -- ^ sizei
@@ -625,6 +628,9 @@ instance GetPName PName1I where
         GetMaxFragmentUniformComponents -> Just gl_MAX_FRAGMENT_UNIFORM_COMPONENTS
         GetMaxVaryingFloats -> Just gl_MAX_VARYING_COMPONENTS
         GetMaxVertexAttribs -> Just gl_MAX_VERTEX_ATTRIBS
+        -- tessellation
+        GetMaxPatchVertices -> Just gl_MAX_PATCH_VERTICES
+        GetMaxTessellationLevel -> Just gl_MAX_TESS_GEN_LEVEL
         -- coordtrans
         GetMatrixMode -> Just gl_MATRIX_MODE
         GetModelviewStackDepth -> Just gl_MODELVIEW_STACK_DEPTH

--- a/src/Graphics/Rendering/OpenGL/GL/Shaders/Limits.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/Shaders/Limits.hs
@@ -15,7 +15,8 @@
 module Graphics.Rendering.OpenGL.GL.Shaders.Limits (
    maxVertexTextureImageUnits, maxTextureImageUnits,
    maxCombinedTextureImageUnits, maxTextureCoords, maxVertexUniformComponents,
-   maxFragmentUniformComponents, maxVertexAttribs, maxVaryingFloats
+   maxFragmentUniformComponents, maxVertexAttribs, maxVaryingFloats,
+   maxTessellationLevel
 ) where
 
 import Graphics.Rendering.OpenGL.GL.StateVar
@@ -75,6 +76,11 @@ maxVertexAttribs = getLimit GetMaxVertexAttribs
 
 maxVaryingFloats :: GettableStateVar GLsizei
 maxVaryingFloats = getLimit GetMaxVaryingFloats
+
+-- | Contains the maximum allowed tessellation level.
+
+maxTessellationLevel :: GettableStateVar GLint
+maxTessellationLevel = makeGettableStateVar $ getInteger1 id GetMaxTessellationLevel
 
 getLimit :: PName1I -> GettableStateVar GLsizei
 getLimit = makeGettableStateVar . getSizei1 id

--- a/src/Graphics/Rendering/OpenGL/GL/TransformFeedback.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/TransformFeedback.hs
@@ -33,6 +33,7 @@ import Foreign.Marshal.Array
 import Graphics.Rendering.OpenGL.GL.ByteString
 import Graphics.Rendering.OpenGL.GL.DataType
 import Graphics.Rendering.OpenGL.GL.PrimitiveMode
+import Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal
 import Graphics.Rendering.OpenGL.GL.QueryUtils
 import Graphics.Rendering.OpenGL.GL.Shaders.Program
 import Graphics.Rendering.OpenGL.GL.Shaders.Variables

--- a/src/Graphics/Rendering/OpenGL/GL/VertexArrays.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/VertexArrays.hs
@@ -42,6 +42,7 @@ import Graphics.Rendering.OpenGL.GL.Capability
 import Graphics.Rendering.OpenGL.GL.DataType
 import Graphics.Rendering.OpenGL.GL.GLboolean
 import Graphics.Rendering.OpenGL.GL.PrimitiveMode
+import Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal
 import Graphics.Rendering.OpenGL.GL.QueryUtils
 import Graphics.Rendering.OpenGL.GL.StateVar
 import Graphics.Rendering.OpenGL.GL.Texturing.TextureUnit

--- a/src/Graphics/Rendering/OpenGL/GLU/NURBS.hs
+++ b/src/Graphics/Rendering/OpenGL/GLU/NURBS.hs
@@ -44,6 +44,7 @@ import Graphics.Rendering.OpenGL.GL.CoordTrans
 import Graphics.Rendering.OpenGL.GL.Exception
 import Graphics.Rendering.OpenGL.GL.GLboolean
 import Graphics.Rendering.OpenGL.GL.PrimitiveMode
+import Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal
 import Graphics.Rendering.OpenGL.GL.VertexSpec
 import Graphics.Rendering.OpenGL.GLU.ErrorsInternal
 import Graphics.Rendering.OpenGL.Raw

--- a/src/Graphics/Rendering/OpenGL/GLU/Tessellation.hs
+++ b/src/Graphics/Rendering/OpenGL/GLU/Tessellation.hs
@@ -3,7 +3,7 @@
 -- Module      :  Graphics.Rendering.OpenGL.GLU.Tessellation
 -- Copyright   :  (c) Sven Panne 2002-2013
 -- License     :  BSD3
--- 
+--
 -- Maintainer  :  Sven Panne <svenpanne@gmail.com>
 -- Stability   :  stable
 -- Portability :  portable
@@ -48,9 +48,9 @@ import Graphics.Rendering.OpenGL.GL.Tensor
 import Graphics.Rendering.OpenGL.GL.EdgeFlag ( unmarshalEdgeFlag )
 import Graphics.Rendering.OpenGL.GL.Exception ( bracket )
 import Graphics.Rendering.OpenGL.GL.GLboolean ( marshalGLboolean )
-import Graphics.Rendering.OpenGL.GL.PrimitiveMode ( unmarshalPrimitiveMode )
-import Graphics.Rendering.OpenGL.GL.BeginEnd (
-   PrimitiveMode, EdgeFlag(BeginsInteriorEdge) )
+import Graphics.Rendering.OpenGL.GL.PrimitiveMode ( PrimitiveMode )
+import Graphics.Rendering.OpenGL.GL.PrimitiveModeInternal ( unmarshalPrimitiveMode )
+import Graphics.Rendering.OpenGL.GL.BeginEnd ( EdgeFlag(BeginsInteriorEdge) )
 import Graphics.Rendering.OpenGL.GL.VertexSpec
 import Graphics.Rendering.OpenGL.GL.QueryUtils
 import Graphics.Rendering.OpenGL.GLU.ErrorsInternal


### PR DESCRIPTION
Address issue #52: Add functions and two limit constants (`GettableStateVars`) vital for
(shader-based) tessellation. To better resemble the newest OpenGL specs,
make `PrimitiveMode` a public module and move its marshaling functionality
to a new internal module `PrimitiveModeInternal`.

I'm not quite sure about the placement of `maxPatchVertices` and `maxTessellationLevel`.