### PR TITLE
Add vertexAttribDivisor for instanced rendering.

### DIFF
--- a/src/Graphics/Rendering/OpenGL/GL/QueryUtils/VertexAttrib.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/QueryUtils/VertexAttrib.hs
@@ -41,6 +41,7 @@ data GetVertexAttribPName =
    | GetCurrentVertexAttrib
    | GetVertexAttribArrayBufferBinding
    | GetVertexAttribArrayInteger
+   | GetVertexAttribArrayDivisor
 
 marshalGetVertexAttribPName :: GetVertexAttribPName -> GLenum
 marshalGetVertexAttribPName x = case x of
@@ -52,6 +53,7 @@ marshalGetVertexAttribPName x = case x of
    GetCurrentVertexAttrib -> GL_CURRENT_VERTEX_ATTRIB
    GetVertexAttribArrayBufferBinding -> GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING
    GetVertexAttribArrayInteger -> GL_VERTEX_ATTRIB_ARRAY_INTEGER
+   GetVertexAttribArrayDivisor -> GL_VERTEX_ATTRIB_ARRAY_DIVISOR
 
 --------------------------------------------------------------------------------
 

--- a/src/Graphics/Rendering/OpenGL/GL/VertexArrays.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/VertexArrays.hs
@@ -44,7 +44,7 @@ module Graphics.Rendering.OpenGL.GL.VertexArrays (
    primitiveRestartIndex, primitiveRestartIndexNV,
 
    -- * Generic Vertex Attribute Arrays
-   vertexAttribPointer, vertexAttribArray,
+   vertexAttribPointer, vertexAttribArray, vertexAttribDivisor
 ) where
 
 import Data.StateVar
@@ -482,3 +482,9 @@ getVertexAttribArray location =
 setVertexAttribArray :: Capability -> AttribLocation -> IO ()
 setVertexAttribArray Disabled (AttribLocation location) = glDisableVertexAttribArray location
 setVertexAttribArray Enabled (AttribLocation location) = glEnableVertexAttribArray location
+
+--------------------------------------------------------------------------------
+
+vertexAttribDivisor :: AttribLocation -> StateVar GLuint
+vertexAttribDivisor attribLocation @ (AttribLocation location) =
+   makeStateVar (getVertexAttribEnum1 fromIntegral attribLocation GetVertexAttribArrayDivisor) (glVertexAttribDivisor location)


### PR DESCRIPTION
I find some functions for instanced rendering like drawArraysInstanced in this OpenGL binding, but vertexAttribDivisor does not expoded.

I think vertexAttribDivisor is also needed for instanced rendering.