### PR TITLE
Add missing API abstractions

### DIFF
--- a/src/Graphics/Rendering/OpenGL/GL/Shaders/ShaderObjects.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/Shaders/ShaderObjects.hs
@@ -18,6 +18,7 @@ module Graphics.Rendering.OpenGL.GL.Shaders.ShaderObjects (
    shaderCompiler,
    ShaderType(..), Shader, createShader,
    shaderSourceBS, shaderSource, compileShader, releaseShaderCompiler,
+   shaderSpecialization,
 
    -- * Shader Queries
    shaderType, shaderDeleteStatus, compileStatus, shaderInfoLog,
@@ -32,6 +33,7 @@ import Data.StateVar
 import Foreign.Marshal.Alloc
 import Foreign.Marshal.Array
 import Foreign.Marshal.Utils
+import Foreign.Ptr
 import Foreign.Storable
 import Graphics.Rendering.OpenGL.GL.ByteString
 import Graphics.Rendering.OpenGL.GL.GLboolean
@@ -115,6 +117,14 @@ compileShader = glCompileShader . shaderID
 
 releaseShaderCompiler :: IO ()
 releaseShaderCompiler = glReleaseShaderCompiler
+
+--------------------------------------------------------------------------------
+
+shaderSpecialization :: Shader -> SettableStateVar (String, GLuint, Ptr GLuint, Ptr GLuint)
+shaderSpecialization (Shader shader) =
+    makeSettableStateVar $ \(entrypoint, numConsts, constantIDs, constantVals) -> do
+        entry <- withGLstring entrypoint return
+        glSpecializeShader shader entry numConsts constantIDs constantVals
 
 --------------------------------------------------------------------------------
 

--- a/src/Graphics/Rendering/OpenGL/GL/Texturing/Specification.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/Texturing/Specification.hs
@@ -66,6 +66,9 @@ module Graphics.Rendering.OpenGL.GL.Texturing.Specification (
    -- * Multisample Texture Images
    SampleLocations(..), texImage2DMultisample, texImage3DMultisample,
 
+   -- * Immutable-Format Texture Images
+   texStorage2D, texStorage3D,
+
    -- * Implementation-Dependent Limits
    maxTextureSize, maxCubeMapTextureSize, maxRectangleTextureSize,
    max3DTextureSize, maxArrayTextureLayers, maxSampleMaskWords,
@@ -318,6 +321,34 @@ texImage3DMultisample target proxy (Samples s) int (TextureSize3D w h d) loc =
    glTexImage3DMultisample
       (marshalMultisample proxy target) s (fromIntegral (marshalPixelInternalFormat int))
       w h d (marshalSampleLocations loc)
+
+--------------------------------------------------------------------------------
+
+texStorage2D
+    :: TwoDimensionalTextureTarget t
+    => t
+    -> Proxy
+    -> Level
+    -> PixelInternalFormat
+    -> TextureSize2D
+    -> IO ()
+texStorage2D target proxy levels int (TextureSize2D w h) =
+    glTexStorage2D
+        (marshalTwoDimensionalTextureTarget proxy target)
+        levels (fromIntegral (marshalPixelInternalFormat int)) w h
+
+texStorage3D
+    :: ThreeDimensionalTextureTarget t
+    => t
+    -> Proxy
+    -> Level
+    -> PixelInternalFormat
+    -> TextureSize3D
+    -> IO ()
+texStorage3D target proxy levels int (TextureSize3D w h d) =
+    glTexStorage3D
+        (marshalThreeDimensionalTextureTarget proxy target)
+        levels (fromIntegral (marshalPixelInternalFormat int)) w h d
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Currently, there is no convenient way to specialize shaders, so this
commit adds a way to do so via a SettableStateVar.

Fixes https://github.com/haskell-opengl/OpenGL/issues/92