### PR TITLE
Exposining VertexArrayObject type constructor, instancing Generic

### DIFF
--- a/src/Graphics/Rendering/OpenGL/GL/VertexArrayObjects.hs
+++ b/src/Graphics/Rendering/OpenGL/GL/VertexArrayObjects.hs
@@ -9,9 +9,9 @@
 -- Portability :  portable
 --
 -----------------------------------------------------------------------------
-
+{-# LANGUAGE DeriveGeneric #-}
 module Graphics.Rendering.OpenGL.GL.VertexArrayObjects (
-   VertexArrayObject,
+   VertexArrayObject (..),
    bindVertexArrayObject
 ) where
 
@@ -23,11 +23,12 @@ import Graphics.Rendering.OpenGL.GL.DebugOutput
 import Graphics.Rendering.OpenGL.GL.GLboolean
 import Graphics.Rendering.OpenGL.GL.QueryUtils
 import Graphics.GL
-
+import GHC.Generics
+  
 -----------------------------------------------------------------------------
 
 newtype VertexArrayObject = VertexArrayObject { vertexArrayID :: GLuint }
-   deriving( Eq, Ord, Show )
+   deriving( Eq, Ord, Show, Generic )
 
 instance ObjectName VertexArrayObject where
    isObjectName =


### PR DESCRIPTION
Hey svenpanne, 

This commit exposes VertexArrayObject type constructor and makes it an instance of Generic.  That makes it trivial to derive instances of other useful types like Binary (which is my use case). 

I am not sure if it breaks anything in the greater scheme of things.
What do you think?


Cheers!